### PR TITLE
Adding custom prop name

### DIFF
--- a/src/keypath.js
+++ b/src/keypath.js
@@ -35,7 +35,7 @@
             return mod;
         };
     }
-}(this, "keypath", function() {
+}(this, 'keypath', function() {
 
 
     var Keypath = {};
@@ -91,8 +91,8 @@
         return undefined;
     };
 
-    Keypath.wrap = function(target, inject) {
-        var wrapper = new Wrapper(target);
+    Keypath.wrap = function(target, inject, dataPropName) {
+        var wrapper = new Wrapper(target, dataPropName);
         if (!inject) return wrapper;
         if (typeof inject === 'function') inject(target, wrapper);
         if (typeof inject === 'string') Keypath.set(target, inject, wrapper);
@@ -121,20 +121,34 @@
      * Wrapper Constructor
      * @param {Object} target Object to be wrapped
      */
-    function Wrapper(target) {
-        this.target = target;
+
+    function Wrapper(target, prop) {
+        this._target = target;
+
+        prop = prop || 'target';
+        wrapOnce(prop);
+    }
+    var defined = false;
+    function wrapOnce(prop){
+        if(defined) return;
+        defined = true;
+        Object.defineProperty(Wrapper.prototype, prop, {
+            get: function() {
+                return this._target;
+            }
+        });
     }
 
     Wrapper.prototype.set = function(path, value) {
-        return Keypath.set(this.target, path, value);
+        return Keypath.set(this._target, path, value);
     };
 
     Wrapper.prototype.get = function(path, defaultValue) {
-        return Keypath.get(this.target, path, defaultValue);
+        return Keypath.get(this._target, path, defaultValue);
     };
 
     Wrapper.prototype.has = function(path) {
-        return Keypath.has(this.target, path);
+        return Keypath.has(this._target, path);
     };
 
     Keypath.Wrapper = Wrapper;

--- a/src/keypath.js
+++ b/src/keypath.js
@@ -123,21 +123,12 @@
      */
 
     function Wrapper(target, prop) {
-        this._target = target;
-
         prop = prop || 'target';
-        wrapOnce(prop);
+        
+        this[prop]   =
+        this._target = target;
     }
-    var defined = false;
-    function wrapOnce(prop){
-        if(defined) return;
-        defined = true;
-        Object.defineProperty(Wrapper.prototype, prop, {
-            get: function() {
-                return this._target;
-            }
-        });
-    }
+
 
     Wrapper.prototype.set = function(path, value) {
         return Keypath.set(this._target, path, value);


### PR DESCRIPTION
Add the ability to set the name we want to export the data object when we wrap our object.

```js
Keypath.wrap(config, null, 'data');
console.log(config.data);
```