### PR TITLE
Fix target use of hasOwnProperty when we migth have proxy

### DIFF
--- a/src/keypath.js
+++ b/src/keypath.js
@@ -70,7 +70,7 @@
             p = '';
         for (; i < l; ++i) {
             p = path[i];
-            if (target.hasOwnProperty(p)) target = target[p];
+            if (target[p] !== undefined) target = target[p];
             else return Keypath._get(defaultValue);
         }
         return Keypath._get(target);


### PR DESCRIPTION
This will close #7 by checking for `undefined` rather than using `hasOwnProperty` which fails in legit use cases, like if target is a Proxy instance.