### PR TITLE
Add array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ $ npm i gkeypath
 ## Examples
 
 ```js
-let foo = { bar: { baz: 'fiz' } };
+let foo = { bar: { baz: 'fiz',  buzs: ['fizbuz']} };
 
 console.log(KeyPath.get(foo, 'bar.baz')); //fiz
 console.log(foo.path.get('bar.bar')); //undefined
+console.log(foo.path.get('bar.baz.buzs[0]')); //fizbuz
 console.log(foo.path.get('bar.bar', 'fuz')); //fuz
 ```
 
@@ -31,13 +32,14 @@ You can wrap your object to get a `get` and `set` functions to access values.
 The wrap function has different signatures.
 
 ```js
-let foo = { bar: { baz: 'fiz' } };
+let foo = { bar: { baz: 'fiz',  buzs: ['fizbuz']} };
 
-KeyPath.wrap(foo, 'path');
+KeyPath.wrap(foo, '_keypath_');
 
-console.log(foo.path.get('bar.baz')); //fiz
-console.log(foo.path.get('bar.bar')); //undefined
-console.log(foo.path.get('bar.bar', 'fuz')); //fuz
+console.log(foo._keypath_.get('bar.baz')); //fiz
+console.log(foo._keypath_.get('bar.bar')); //undefined
+console.log(foo._keypath_.get('bar.baz.buzs[0]')); //fizbuz
+console.log(foo._keypath_.get('bar.bar', 'fuz')); //fuz
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
-# Keypath
+# KeyPath
 
 [![Build Status](https://secure.travis-ci.org/goliatone/gkeypath.png)](http://travis-ci.org/goliatone/gkeypath)
 
 Helper library to get/set keypaths on any object.
 
 ## Documentation
-`Keypath` is defined as a [requirejs][1] module.
+
+`KeyPath` is defined as a [requirejs][1] module. 
+
+It can  be imported as a `npm` package to be used in Node.js applications:
+
+```
+$ npm i gkeypath
+```
 
 ## Examples
 
-```javascript
-var Foo = {bar:{baz:'fiz'}};
-console.log(Keypath.get(Foo, 'bar.baz')); //fiz
-console.log(Foo.path.get('bar.bar')); //undefined
-console.log(Foo.path.get('bar.bar', 'fuz')); //fuz
+```js
+let foo = { bar: { baz: 'fiz' } };
+
+console.log(KeyPath.get(foo, 'bar.baz')); //fiz
+console.log(foo.path.get('bar.bar')); //undefined
+console.log(foo.path.get('bar.bar', 'fuz')); //fuz
 ```
 
 #### Wrapping
@@ -22,32 +30,32 @@ You can wrap your object to get a `get` and `set` functions to access values.
 
 The wrap function has different signatures.
 
-```javascript
-var Foo = {bar:{baz:'fiz'}};
+```js
+let foo = { bar: { baz: 'fiz' } };
 
-Keypath.wrap(Foo, 'path');
+KeyPath.wrap(foo, 'path');
 
-console.log(Foo.path.get('bar.baz')); //fiz
-console.log(Foo.path.get('bar.bar')); //undefined
-console.log(Foo.path.get('bar.bar', 'fuz')); //fuz
+console.log(foo.path.get('bar.baz')); //fiz
+console.log(foo.path.get('bar.bar')); //undefined
+console.log(foo.path.get('bar.bar', 'fuz')); //fuz
 ```
 
-```javascript
-var Foo = {bar:{baz:'fiz'}};
+```js
+let foo = { bar: { baz: 'fiz' } };
 
-Keypath.wrap(Foo, function(target, wrapper){
+KeyPath.wrap(foo, (target, wrapper) => {
     ...
 });
 ```
 
-#### Proxy
+##### Proxy
 
-If available, the wrapped object will be also wrapped in an ES6 Proxy object, in which case you can access properties using dot notation instead of having to use the `get`/`set` functions.
+The wrapped object will be wrapped in an ES6 Proxy object, in which case you can access properties using dot notation instead of having to use the `get`/`set` functions.
 
 ```js
-var config = {bar:{baz:'fiz'}};
+let config = { bar: { baz: 'fiz' } };
 
-config = Keypath.wrap(config);
+config = KeyPath.wrap(config);
 
 console.log(config.bar.baz) //fiz
 ```

--- a/src/keypath.js
+++ b/src/keypath.js
@@ -55,6 +55,16 @@
             if (!target[prop]) target[prop] = {};
             target = target[prop];
         });
+        /**
+         * We do not support `...` but we could 
+         * extend to enable array concatenation
+         */
+        if (path.match(/\w+\[(\d+)\]/)) {
+            let [_, name, index] = path.match(/(\w+)\[(\d+)\]/);
+            if (!Array.isArray(target[name])) target[name] = [];
+            target = target[name];
+            path = index;
+        }
 
         Keypath._set(target, path, value); //target[path] = value;
 
@@ -70,6 +80,12 @@
             p = '';
         for (; i < l; ++i) {
             p = path[i];
+            if (p.match(/\w+\[(\d+)\]/)) {
+                let [_, name, index] = p.match(/(\w+)\[(\d+)\]/);
+                target = target[name];
+                if (!target) return defaultValue;
+                p = index;
+            }
             if (target[p] !== undefined) target = target[p];
             else return Keypath._get(defaultValue);
         }


### PR DESCRIPTION
Added support for array notation, closes #15. 
You can now do `KeyPath.set(foo, 'bar.baz[0]', 'item')` and `KeyPath.get(foo, 'bar.baz[0]')`.