### PR TITLE
Add options get

### DIFF
--- a/src/keypath.js
+++ b/src/keypath.js
@@ -44,7 +44,7 @@
         assertionMessage: 'Assertion failed'
     };
 
-    Keypath.VERSION = '0.10.1';
+    Keypath.VERSION = '0.11.1';
 
     /**
      * Set a value in target following keypath.

--- a/test/keypath_test.js
+++ b/test/keypath_test.js
@@ -126,3 +126,31 @@ test('KeyPath should return defaultValue if oneOf does not match', t => {
 
     t.end();
 });
+
+test('KeyPath should optionally not execute functions', t => {
+
+    const defaultFunction = _ => {};
+
+    let out = { bar: { baz: defaultFunction } };
+    let expected = defaultFunction;
+
+    let result = KeyPath.get(out, 'bar.baz', undefined, { useGetters: false });
+
+    t.equal(result, expected);
+
+    t.end();
+});
+
+test('KeyPath should optionally not execute functions in default value', t => {
+
+    const defaultFunction = _ => {};
+
+    let out = { bar: { baz: 'fiz', fiz: ['buzz', 'light'] } };
+    let expected = defaultFunction;
+
+    let result = KeyPath.get(out, 'bar.XX', defaultFunction, { useGetters: false });
+
+    t.equal(result, expected);
+
+    t.end();
+});


### PR DESCRIPTION
This closes #13 by taking an options object with a `useGetters` option which if we set it to `false` it will return functions without executing them. 

The default value is `true` to match backwards compatible behavior. Will change in a future 1.x release since it would be a breaking change.