### PR TITLE
fix: handle target null

### DIFF
--- a/src/keypath.js
+++ b/src/keypath.js
@@ -101,12 +101,19 @@
             p = '';
         for (; i < l; ++i) {
             p = path[i];
+
+            /**
+             * Handle array syntax: e.g. `arrayName.1`
+             */
             if (p.match(/\w+\[(\d+)\]/)) {
                 let [_, name, index] = p.match(/(\w+)\[(\d+)\]/);
                 target = target[name];
                 if (!target) return defaultValue;
                 p = index;
             }
+
+            if (target === null) return Keypath._get(defaultValue, o);
+
             if (target[p] !== undefined) target = target[p];
             else return Keypath._get(defaultValue, o);
         }

--- a/test/keypath_test.js
+++ b/test/keypath_test.js
@@ -59,8 +59,7 @@ test('KeyPath should set objects ', t => {
     t.end();
 });
 
-
-test.only('KeyPath should set objects ', t => {
+test('KeyPath should set objects ', t => {
 
     let expected = {
         user: {
@@ -120,25 +119,37 @@ test('KeyPath should return oneOf ', t => {
     t.end();
 });
 
+
 test('KeyPath should return defaultValue if either target or path are undefined', t => {
     let out = { bar: { baz: 'fiz', fiz: ['buzz', 'light'] } };
 
     let expected = 'default';
 
     let result = KeyPath.get(out, undefined, expected);
-
     t.equal(result, expected);
 
     result = KeyPath.get(out, '', expected);
+    t.equal(result, expected);
 
+    result = KeyPath.get(out, 'bar.undefined.fiz', expected);
     t.equal(result, expected);
 
     result = KeyPath.get(undefined, 'path', expected);
-
     t.equal(result, expected);
 
     result = KeyPath.get(undefined, undefined, expected);
+    t.equal(result, expected);
 
+    result = KeyPath.get(undefined, 'bar.baz', expected);
+    t.equal(result, expected);
+
+    result = KeyPath.get({}, 'bar.baz', expected);
+    t.equal(result, expected);
+
+    result = KeyPath.get({ bar: null }, 'bar.baz', expected);
+    t.equal(result, expected);
+
+    result = KeyPath.get({ bar: { baz: null } }, 'bar.baz.fiz', expected);
     t.equal(result, expected);
 
     t.end();


### PR DESCRIPTION
Close #25 by adding a `null` check in the `get` method. Update tests to prevent regresions.